### PR TITLE
Change license to Apache 2.0 and add highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Returns a list of [Showtimes](#showtime) for the given movie and theatre on the 
 ```
 
 # Example
-```
+```javascript
 const cineplexScraper = require('cineplex-scraper');
 
 let theatres = [];

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "Stuart Wilcox",
-  "license": "ISC",
+  "license": "Apache-2.0",
   "dependencies": {
     "jsdom": "^13.1.0",
     "node-fetch": "^2.3.0"


### PR DESCRIPTION
License was previously ISC, which is incorrect because the project uses
the Apache 2.0 license.
Also add syntax highlighting to example in README